### PR TITLE
Add per-page meta tags from markdown shorthand

### DIFF
--- a/agave-generator.opam
+++ b/agave-generator.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "agave-generator"
-version: "0.2.0"
+version: "0.2.1"
 synopsis: "Minimal markdown to HTML static site generator"
 description: """
 Minimal markdown to HTML for static sites with pretty URLs.

--- a/lib/GenerateSite.re
+++ b/lib/GenerateSite.re
@@ -31,6 +31,192 @@ let regexmarkdown = Str.regexp("<!-- MARKDOWN -->");
 let addmarkdown: (string, string) => string =
   (template, content) => Str.replace_first(regexmarkdown, content, template);
 
+type metadata = {
+  title: option(string),
+  description: option(string),
+  image: option(string),
+};
+
+let emptyMeta = {title: None, description: None, image: None};
+
+let shorthandRegex = Str.regexp("@\\([a-zA-Z]+\\) \\(.*\\)");
+
+let parseShorthand: string => (metadata, string) =
+  rawContent => {
+    let lines = String.split_on_char('\n', rawContent);
+    let rec loop = (lines, meta) =>
+      switch (lines) {
+      | [line, ...rest] when String.length(line) > 0 && line.[0] == '@' =>
+        if (Str.string_match(shorthandRegex, line, 0)) {
+          let key = Str.matched_group(1, line);
+          let value = Str.matched_group(2, line);
+          let meta =
+            switch (key) {
+            | "title" => {...meta, title: Some(value)}
+            | "description" => {...meta, description: Some(value)}
+            | "image" => {...meta, image: Some(value)}
+            | _ => meta
+            };
+          loop(rest, meta);
+        } else {
+          (meta, String.concat("\n", [line, ...rest]));
+        }
+      | _ => (meta, String.concat("\n", lines))
+      };
+    loop(lines, emptyMeta);
+  };
+
+let headingRegex = Str.regexp("^# \\(.*\\)$");
+
+let extractFirstHeading: string => option(string) =
+  content => {
+    let lines = String.split_on_char('\n', content);
+    let rec find =
+      fun
+      | [] => None
+      | [line, ...rest] =>
+        if (Str.string_match(headingRegex, line, 0)) {
+          Some(Str.matched_group(1, line));
+        } else {
+          find(rest);
+        };
+    find(lines);
+  };
+
+let extractFirstParagraph: string => option(string) =
+  content => {
+    let lines = String.split_on_char('\n', content);
+    let rec find =
+      fun
+      | [] => None
+      | [line, ...rest] => {
+          let trimmed = String.trim(line);
+          if (String.length(trimmed) > 0
+              && trimmed.[0] != '#'
+              && trimmed.[0] != '!'
+              && trimmed.[0] != '-'
+              && trimmed.[0] != '*'
+              && trimmed.[0] != '`') {
+            Some(trimmed);
+          } else {
+            find(rest);
+          };
+        };
+    find(lines);
+  };
+
+let imageRegex = Str.regexp("!\\[.*\\](\\(.*\\))");
+
+let extractFirstImage: string => option(string) =
+  content =>
+    try({
+      let _ = Str.search_forward(imageRegex, content, 0);
+      Some(Str.matched_group(1, content));
+    }) {
+    | Not_found => None
+    };
+
+let titleRegex = Str.regexp("<title>\\([^<]*\\)</title>");
+
+let extractBaseTitle: string => string =
+  basehtml =>
+    try({
+      let _ = Str.search_forward(titleRegex, basehtml, 0);
+      Str.matched_group(1, basehtml);
+    }) {
+    | Not_found => "Agave Site"
+    };
+
+let escapeHtml: string => string =
+  s =>
+    s
+    |> Str.global_replace(Str.regexp("&"), "&amp;")
+    |> Str.global_replace(Str.regexp("\""), "&quot;")
+    |> Str.global_replace(Str.regexp("<"), "&lt;")
+    |> Str.global_replace(Str.regexp(">"), "&gt;");
+
+let buildMetaTags: (metadata, string, string) => (string, string) =
+  (meta, markdown, basehtml) => {
+    let baseTitle = extractBaseTitle(basehtml);
+    let pageTitle =
+      switch (meta.title) {
+      | Some(t) => t
+      | None =>
+        switch (extractFirstHeading(markdown)) {
+        | Some(h) => h ++ " | " ++ baseTitle
+        | None => baseTitle
+        }
+      };
+    let description =
+      switch (meta.description) {
+      | Some(d) => Some(d)
+      | None => extractFirstParagraph(markdown)
+      };
+    let image =
+      switch (meta.image) {
+      | Some(i) => Some(i)
+      | None => extractFirstImage(markdown)
+      };
+    let tags = ref("");
+    tags :=
+      tags^
+      ++ "\n    <meta property=\"og:title\" content=\""
+      ++ escapeHtml(pageTitle)
+      ++ "\" />"
+      ++ "\n    <meta name=\"twitter:title\" content=\""
+      ++ escapeHtml(pageTitle)
+      ++ "\" />";
+    switch (description) {
+    | Some(d) =>
+      tags :=
+        tags^
+        ++ "\n    <meta name=\"description\" content=\""
+        ++ escapeHtml(d)
+        ++ "\" />"
+        ++ "\n    <meta property=\"og:description\" content=\""
+        ++ escapeHtml(d)
+        ++ "\" />"
+        ++ "\n    <meta name=\"twitter:description\" content=\""
+        ++ escapeHtml(d)
+        ++ "\" />"
+    | None => ()
+    };
+    switch (image) {
+    | Some(i) =>
+      tags :=
+        tags^
+        ++ "\n    <meta property=\"og:image\" content=\""
+        ++ escapeHtml(i)
+        ++ "\" />"
+        ++ "\n    <meta name=\"twitter:image\" content=\""
+        ++ escapeHtml(i)
+        ++ "\" />"
+        ++ "\n    <meta name=\"twitter:card\" content=\"summary_large_image\" />"
+    | None =>
+      tags :=
+        tags^
+        ++ "\n    <meta name=\"twitter:card\" content=\"summary\" />"
+    };
+    (pageTitle, tags^);
+  };
+
+let headCloseRegex = Str.regexp("</head>");
+
+let injectMetaTags: (string, string, string) => string =
+  (html, pageTitle, metaTags) => {
+    let withTitle =
+      Str.global_replace(
+        titleRegex,
+        "<title>" ++ escapeHtml(pageTitle) ++ "</title>",
+        html,
+      );
+    Str.replace_first(
+      headCloseRegex,
+      metaTags ++ "\n  </head>",
+      withTitle,
+    );
+  };
+
 exception NotADirectory(string);
 
 let mkdir: string => unit =
@@ -83,17 +269,23 @@ let rec buildfiletree: (string, string, string) => string =
 
     markdownfiles
     |> List.fold_left(
-         (a, b) =>
-           readf("./" ++ inputdir ++ "/" ++ b)
+         (a, b) => {
+           let rawContent = readf("./" ++ inputdir ++ "/" ++ b);
+           let (meta, markdown) = parseShorthand(rawContent);
+           let (pageTitle, metaTags) =
+             buildMetaTags(meta, markdown, basehtml);
+           markdown
            |> Omd.of_string
            |> Omd.to_html
            |> addmarkdown(basehtml)
+           |> injectMetaTags(_, pageTitle, metaTags)
            |> writef(buildoutdir(b, outputdir) ++ "/index.html")
            |> (
              () =>
                green("🍯" ++ b ++ "\n")
                ++ a
-           ),
+           );
+         },
          "",
        );
   };


### PR DESCRIPTION
## Summary
- Add `@title`, `@description`, `@image` shorthand notation at the top of markdown files to generate per-page OG and Twitter meta tags
- Fallback chain: shorthand values → first heading/paragraph/image in markdown → base template defaults
- Bump version to 0.2.1

## Test plan
- [x] `dune build` compiles cleanly
- [x] Full shorthand file: all three `@` directives produce correct meta tags, lines stripped from body
- [x] No shorthand file: falls back to first heading + base title, first paragraph, first image
- [x] Partial shorthand file: explicit `@title` used, description falls back to first paragraph, no image omits `og:image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)